### PR TITLE
Limits images to the space they have

### DIFF
--- a/Template/printlayout/description.php
+++ b/Template/printlayout/description.php
@@ -2,6 +2,12 @@
     <div class="accordion-title">
         <h3><a href="#" class="fa accordion-toggle"></a> <?= t('Description') ?></h3>
     </div>
+    <style>
+	img {
+		max-width:100%;
+		max-height:100%;
+	}
+    </style>
     <div class="accordion-content">
         <article class="markdown">
             <?= $this->text->markdown($this->task->printModel->codeblockFix($task['description']), isset($is_public) && $is_public) ?>


### PR DESCRIPTION
small CSS added so images wont outgrow their respective containers (Divs, Tables, etc.)